### PR TITLE
feat/페이지 이동 시 스크롤 위치 조정/#50

### DIFF
--- a/src/Router/App.jsx
+++ b/src/Router/App.jsx
@@ -5,11 +5,13 @@ import LoginPage from '../pages/login/LoginPage';
 import RegisterPage from '../pages/register/RegisterPage';
 import IntroPage from '../pages/intro/IntroPage';
 import MyPage from '../pages/mypage/MyPage';
+import ScrollToTop from '../components/public_components/ScrollToTop';
 
 export default function App() {
   return (
     <>
       <BrowserRouter>
+        <ScrollToTop />
         <Routes>
           <Route path="/" element={<MainPage />}></Route>
           <Route path="/login" element={<LoginPage />}></Route>

--- a/src/components/public_components/ScrollToTop.jsx
+++ b/src/components/public_components/ScrollToTop.jsx
@@ -1,0 +1,15 @@
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    // 페이지 경로가 바뀔 때마다 스크롤을 최상단으로 이동
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
+
+export default ScrollToTop;


### PR DESCRIPTION
useLocation() 함수를 이용하여 페이지의 경로명을 받아온 다음, useEffect와 디펜던시를 이용하여 페이지 경로가 변화할 때마다 ScrollToTop() 함수를 호출하여 스크롤의 위치를 최상단에 위치 시킴