### PR TITLE
찜버튼 버그 수정했습니다

### DIFF
--- a/src/components/page_components/main/FavoriteButton.jsx
+++ b/src/components/page_components/main/FavoriteButton.jsx
@@ -1,6 +1,6 @@
 import { authAxios } from '../../../axios/instance';
 import * as S from './MainStyled';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { confirmWishListAlert } from '../../public_components/Alert';
 import getUserInfo from '../../../function/getUserInfo';
 export default function FavoriteButton({
@@ -11,6 +11,9 @@ export default function FavoriteButton({
 }) {
   //찜데이터가 있으면 찜데이터 저장(true) 아님 false
   const [isLiked, setisLiked] = useState(wishData || false);
+  useEffect(() => {
+    setisLiked(wishData || false);
+  }, [wishData]);
   const wishListId = typeof wishData === 'object' ? wishData.wishListId : null;
   const baseUrl = import.meta.env.VITE_IMG_BASE_URL;
   const [userId] = getUserInfo();


### PR DESCRIPTION
찜이 되어있음에도 찜으로 표시가 안되던 버그 수정했습니다
props로 찜 데이터를 받는데 맨 처음 랜더링 된 후 props로 다시 데이터를 받을 때 props가 바뀌어도 리랜더링이 안되다보니 버그가 발생한 거 같습니다
간단하게 useEffect에 의존성배열로 찜정보를 넣어서 다시 랜더링되도록 수정했습니다.